### PR TITLE
feat: add Laravel 12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.0.0] - 2024-03-XX
+
+### Added
+- Laravel 12.x support
+- PHP 8.2+ requirement
+
+### Changed
+- Updated minimum Laravel version to 12.0
+- Updated composer dependencies
+- Updated illuminate packages to support Laravel 12
+
+### Compatibility
+- Now supports Laravel 10.x, 11.x, and 12.x
+- Requires PHP 8.2 or higher
+
+## [1.0.9] - Previous version
+
 ## [1.0.8] - 2024-07-15
 ### Added
 - Support for Multi-Tenancy ([#24](https://github.com/ringlesoft/laravel-process-approval/issues/24))

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 This package enables multi-level approval workflows for Eloquent models in your Laravel application. If you have models
 that require review and approval from multiple approvers before execution, this package provides a flexible approval
 process to meet that need.
-> Laravel 10.0 or later
+
+> Supports Laravel 10.x, 11.x, and 12.x
+
+> This package is forked from [@ringlesoft/laravel-process-approval](https://github.com/ringlesoft/laravel-process-approval) with added Laravel 12 support.
 
 The package relies on an existing `Role` management. This can be a custom role management or another package such as
 Spatie's `laravel permissions`.

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,14 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
-        "illuminate/auth": "^10.0|^11.0",
-        "illuminate/broadcasting": "^10.7|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/routing": "^10.24|^11.0"
-    }
-    ,
+        "php": "^8.2",
+        "illuminate/auth": "^10.0|^11.0|^12.0",
+        "illuminate/broadcasting": "^10.7|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/routing": "^10.24|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/console": "^10.0|^11.0|^12.0"
+    },
     "require-dev": {
         "roave/security-advisories": "dev-latest"
     },


### PR DESCRIPTION
- Update composer.json to support Laravel 12.x packages
- Update README.md with Laravel 12.x compatibility notice
- Add CHANGELOG.md entry for version 2.0.0
- Update minimum PHP requirement to 8.2